### PR TITLE
implement optimization for long file

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ impl CfAppLogDetector {
                     self.total_log_lines += 1;
                     self.log_lines_matching += 1;
                     if self.one_line_match {
-                        break
+                        break;
                     }
                 }
                 Err(_err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ impl CfAppLogDetector {
     pub fn process_file(&mut self, path: &str) -> io::Result<()> {
         let reader = io::BufReader::new(fs::File::open(path)?);
 
-        reader
+        let lines = reader
             .lines()
             .filter_map(|line| match line {
                 Ok(line) => Some(line),
@@ -77,18 +77,22 @@ impl CfAppLogDetector {
                     eprintln!("Read failed: {:#?}", msg);
                     None
                 }
-            })
-            .for_each(|line| match CfAppLogDetector::parse_line(&line) {
+            });
+        for line in lines {
+            match CfAppLogDetector::parse_line(&line) {
                 Ok(_log) => {
                     self.total_log_lines += 1;
                     self.log_lines_matching += 1;
-                    // TODO add something to break out on first match
+                    if self.one_line_match {
+                        break;
+                    }
                 }
                 Err(_err) => {
                     // eprintln!("parsing error: {}", _err);
                     self.total_log_lines += 1;
                 }
-            });
+            };
+        }
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,22 +69,13 @@ impl CfAppLogDetector {
     pub fn process_file(&mut self, path: &str) -> io::Result<()> {
         let reader = io::BufReader::new(fs::File::open(path)?);
 
-        let lines = reader
-            .lines()
-            .filter_map(|line| match line {
-                Ok(line) => Some(line),
-                Err(msg) => {
-                    eprintln!("Read failed: {:#?}", msg);
-                    None
-                }
-            });
-        for line in lines {
-            match CfAppLogDetector::parse_line(&line) {
+        for line in reader.lines() {
+            match CfAppLogDetector::parse_line(&line?) {
                 Ok(_log) => {
                     self.total_log_lines += 1;
                     self.log_lines_matching += 1;
                     if self.one_line_match {
-                        break;
+                        break
                     }
                 }
                 Err(_err) => {


### PR DESCRIPTION
This would stop reading the files as soon it find a match. 

<details>

<pre>
<code>

$ time cargo run -- --debug .tmp/sample-match.txt
   Compiling cf-app-log-detector v0.1.0 (/home/olivier/workspace/cf_app_log_detector)
    Finished dev [unoptimized + debuginfo] target(s) in 1.10s
     Running `target/debug/cf-app-log-detector --debug .tmp/sample-match.txt`
[DEBUG] total number of lines: 101
[DEBUG] log lines matching: 101
[DEBUG] percentage matching: 100
.tmp/sample-match.txt is a CF application log [100% line matching]
cargo run -- --debug .tmp/sample-match.txt  0.96s user 0.32s system 107% cpu 1.188 total
 ~/workspace/cf_app_log_detector   optimization-break-on-first-line-matching ● 
$ time cargo run -- --one-line-match --debug .tmp/sample-match.txt
    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
     Running `target/debug/cf-app-log-detector --one-line-match --debug .tmp/sample-match.txt`
[DEBUG] total number of lines: 1
[DEBUG] log lines matching: 1
[DEBUG] percentage matching: 100
.tmp/sample-match.txt is a CF application log [100% line matching]
cargo run -- --one-line-match --debug .tmp/sample-match.txt  0.09s user 0.02s system 98% cpu 0.109 total

</code>
</pre>
</details>